### PR TITLE
Draft: AOT Compat

### DIFF
--- a/HMCMT/examples/coprod2/paraHMCscript.jl
+++ b/HMCMT/examples/coprod2/paraHMCscript.jl
@@ -25,6 +25,6 @@ end
 #
 printstyled("perform HMC sampling in parallel ...\n", color=:blue)
 pids = workers()
-@time (results, hmcstats) = parallelHMCSampler(mtMesh,mtData,invParam,hmcprior,pids)
+(results, hmcstats) = parallelHMCSampler(mtMesh,mtData,invParam,hmcprior,pids)
 
 println("=======================================")

--- a/HMCMT/examples/coprod2/startupfile
+++ b/HMCMT/examples/coprod2/startupfile
@@ -1,4 +1,4 @@
-datafile:        coprod2data.dat 
+datafile:        coprod2data.dat
 modelfile:       coprod2.mod
 burninsamples:   100
 totalsamples:    10000

--- a/HMCMT/examples/dprism3d/paraHMCscript.jl
+++ b/HMCMT/examples/dprism3d/paraHMCscript.jl
@@ -25,6 +25,6 @@ end
 #
 printstyled("perform HMC sampling in parallel ...\n", color=:blue)
 pids = workers()
-@time (results, hmcstats) = parallelHMCSampler(mtMesh,mtData,invParam,hmcprior,pids)
+(results, hmcstats) = parallelHMCSampler(mtMesh,mtData,invParam,hmcprior,pids)
 
 println("=======================================")

--- a/HMCMT/src/AOTCompat.jl
+++ b/HMCMT/src/AOTCompat.jl
@@ -1,0 +1,37 @@
+const _is_win = Sys.iswindows()
+
+function unix_readline(f, windows_line=_is_win)::Union{String, Nothing}
+    line = Char[]
+    try
+        while true
+            c = read(f, Char)
+            if windows_line && c == '\r'
+                c = read(f, Char)
+                @assert c == '\n' "read $c after newline"
+                break
+            end
+            c == '\n' && break
+            push!(line, c)
+        end
+        return String(line)
+    catch e
+        e isa EOFError && begin
+            return String(line)
+        end
+        throw(e)
+    end
+end
+
+
+function _time_seconds()
+    ccall(:time, UInt, (Ptr{Cvoid},), C_NULL)
+end
+
+macro compat_elapsed(ex)
+    quote
+        local t0 = _time_seconds()
+        local val = $(esc(ex))
+        local t1 = _time_seconds()
+        (float(t1 - t0), val)
+    end
+end

--- a/HMCMT/src/HMCFileIO/HMCFileIO.jl
+++ b/HMCMT/src/HMCFileIO/HMCFileIO.jl
@@ -51,10 +51,10 @@ mutable struct TensorMesh2D{T<:Real}
     origin::Vector{T}           # origin of mesh
     sigma::Vector{T}            # conductivity of mesh
 
-    Face::SparseMatrixCSC       # Face area
-    Grad::SparseMatrixCSC       # nodal gradient
-    AveCN::SparseMatrixCSC      # averaging mapping from cell-center to node
-    AveCF::SparseMatrixCSC      # averaging mapping from cell-center to face
+    Face::SparseMatrixCSC{Float64, Int}       # Face area
+    Grad::SparseMatrixCSC{Float64, Int}       # nodal gradient
+    AveCN::SparseMatrixCSC{Float64, Int}      # averaging mapping from cell-center to node
+    AveCF::SparseMatrixCSC{Float64, Int}      # averaging mapping from cell-center to face
     setup::Bool                 # whether operators have been set up or not
 
 end # type

--- a/HMCMT/src/HMCFileIO/readEMModel2D.jl
+++ b/HMCMT/src/HMCFileIO/readEMModel2D.jl
@@ -1,3 +1,4 @@
+using HMCMT: unix_readline
 """
 `readEMModel2D(modelfile)` reads model parameters from a EM2D model file.
 
@@ -10,30 +11,33 @@ Output:
 """
 function readEMModel2D(modelfile::String)
 
-    if isfile(modelfile)
-        fid = open(modelfile, "r")
-    else
-        error("$(modelfile) does not exist, please try again.")
+    fid = try
+        open(modelfile, "r")
+    catch e
+        if e isa Base.IOError
+            println("$(modelfile) does not exist, please try again.")
+        end
+        throw(e)
     end
 
-    yLen = []
-    zLen = []
+    yLen = Float64[]
+    zLen = Float64[]
     nAir = 0
-    airLayer = []
-    gridSize = []
-    sigma = []
-    origin = []
-    resType = []
-    ny = []
-    nz = []
+    airLayer = Float64[]
+    gridSize = Int[]
+    sigma = Float64[]
+    origin = Float64[]
+    resType = ""
+    ny = 0
+    nz = 0
 
     while !eof(fid)
 
-        cline = strip(readline(fid))
+        cline = strip(unix_readline(fid))
 
         # ignore comments and empty lines
-        while cline[1] == '#' || isempty(cline)
-            cline = strip(readline(fid))
+        while startswith(cline, '#') || isempty(cline) || cline == "\r"
+            cline = strip(unix_readline(fid))
         end
 
         # blocks at y-axis
@@ -44,7 +48,7 @@ function readEMModel2D(modelfile::String)
             yLen = zeros(ny)
 
             while nd < ny
-                cline = strip(readline(fid))
+                cline = strip(unix_readline(fid))
                 cline = split(cline)
                 num = length(cline)
                 for i = 1:num
@@ -61,7 +65,7 @@ function readEMModel2D(modelfile::String)
             zLen = zeros(nz)
 
             while nd < nz
-                cline = strip(readline(fid))
+                cline = strip(unix_readline(fid))
                 cline = split(cline)
                 num = length(cline)
                 for i = 1:num
@@ -78,7 +82,7 @@ function readEMModel2D(modelfile::String)
             airLayer = zeros(nAir)
 
             while nd < nAir
-                cline = strip(readline(fid))
+                cline = strip(unix_readline(fid))
                 cline = split(cline)
                 num = length(cline)
                 for i = 1:num
@@ -101,7 +105,7 @@ function readEMModel2D(modelfile::String)
 
             sigma = zeros(nBlock)
             while nd < nBlock
-                cline = strip(readline(fid))
+                cline = strip(unix_readline(fid))
                 cline = split(cline)
                 num = length(cline)
                 for i = 1:num

--- a/HMCMT/src/HMCMT.jl
+++ b/HMCMT/src/HMCMT.jl
@@ -11,6 +11,7 @@ VERSION >= v"1.0.0" && __precompile__()
 
 module HMCMT
 
+include("AOTCompat.jl")
 include("HMCFileIO/HMCFileIO.jl")
 include("MTFwdSolver/MTFwdSolver.jl")
 include("HMCUtility/HMCUtility.jl")

--- a/HMCMT/src/HMCStruct/HMCStruct.jl
+++ b/HMCMT/src/HMCStruct/HMCStruct.jl
@@ -44,8 +44,8 @@ mutable struct HMCParameter{Ti<:Int, Tv<:Float64}
     rhomodel::Vector{Tv}         # conductivity model
     momentum::Vector{Tv}         # momentum parameter
     #
-    invM::AbstractMatrix{Tv}             # inverse of the mass matrix
-    sqrtM::AbstractMatrix{Tv}            # square root of the mass matrix
+    invM::Matrix{Tv}             # inverse of the mass matrix
+    sqrtM::Matrix{Tv}            # square root of the mass matrix
 
 end
 
@@ -76,16 +76,16 @@ mutable struct InvDataModel{T<:Float64}
 
     # observed data and data weighting
     obsData::Vector{ComplexF64}         # observed data
-    dataW::SparseMatrixCSC              # data weighting
+    dataW::SparseMatrixCSC{Float64, Int}              # data weighting
 
     # starting model
     strModel::Vector{T}                 # starting model
     refModel::Vector{T}                 # prior model
 
     # active cell and background model
-    activeCell::SparseMatrixCSC         #
+    activeCell::SparseMatrixCSC{Int, Int}         #
     bgModel::Vector{T}                  # background model keeping constant
-    Wm::SparseMatrixCSC                 # model covariance
+    Wm::SparseMatrixCSC{Float64, Int}                 # model covariance
 
 
 end
@@ -135,7 +135,7 @@ function initHMCPrior()
     regParam = 1.0
 
     hmcprior = HMCPrior(100,500,[0.01,10],0.05,dt,timestep,linearSolver,massType,regParam,0)
-    return hmcprior
+    return hmcprior::HMCPrior{Int,Float64}
 
 end
 

--- a/HMCMT/src/MTFwdSolver/MT2DOperators.jl
+++ b/HMCMT/src/MTFwdSolver/MT2DOperators.jl
@@ -137,6 +137,7 @@ Construct sparse unit matrix, replace the built-in function speye that is deprec
 
 """
 function spunit(n::Integer)
+    # Matrix{Int}(I,n,n)
     return sparse(1.0I, n, n)
 end
 
@@ -147,6 +148,15 @@ end
 """
 function spdiag((x1,x2), (d1,d2), m, n)
     I, J, V = SparseArrays.spdiagm_internal(d1 => x1, d2 => x2)
+
+    # non-sparse form:
+    # M = zeros(m,n)
+    # for i = 1:length(I)
+    #     M[I[i], J[i]] = V[i]
+    # end
+    # return M
+
+    # sparse form:
     return sparse(I, J, V, m, n)
 
 end

--- a/HMCMT/src/MTFwdSolver/mt2DTE.jl
+++ b/HMCMT/src/MTFwdSolver/mt2DTE.jl
@@ -46,7 +46,7 @@ function compMT2DTE(freq::T, mt2dMesh::TensorMesh2D, coeMat::CoeffMat,
     # solve the linear system
     if isempty(linearSolver)
         Ainv = lu(Aii)
-        Eii  = Ainv \ rhs
+        Eii  = collect(Ainv) \ rhs
     elseif lowercase(linearSolver) == "mumps"
         sym  = 1
         Ainv = factorMUMPS(Aii, sym)

--- a/HMCMT/src/MTFwdSolver/mt2DTM.jl
+++ b/HMCMT/src/MTFwdSolver/mt2DTM.jl
@@ -45,7 +45,7 @@ function compMT2DTM(freq::T, mt2dMesh::TensorMesh2D, coeMat::CoeffMat,
     # solve the linear system
     if isempty(linearSolver)
         Ainv = lu(Aii)
-        Hii  = Ainv \ rhs
+        Hii  = collect(Ainv) \ rhs
     elseif lowercase(linearSolver) == "mumps"
         sym  = 1
         Ainv = factorMUMPS(Aii, sym)

--- a/HMCMT/src/MTSensitivity/compJacMat.jl
+++ b/HMCMT/src/MTSensitivity/compJacMat.jl
@@ -208,16 +208,16 @@ function compJacMat(exTE::Array{T}, hxTM::Array{T}, mt2dMesh::TensorMesh2D,
 
             # solve the pseudo forward problem
             if lsFlag == 0
-                @time dExTE[ii, :]  = applyMUMPS(AinvTE[iFreq], PplusB)
+                dExTE[ii, :]  = applyMUMPS(AinvTE[iFreq], PplusB)
 
             elseif lsFlag == 1
-                @time dExTE[ii, :] = AiiTE \ (PplusB)
+                dExTE[ii, :] = AiiTE \ (PplusB)
 
             elseif lsFlag == 2
-                @time dExTE[ii, :] = mumpsSolver(AiiTE, PplusB)
+                dExTE[ii, :] = mumpsSolver(AiiTE, PplusB)
 
             elseif lsFlag == 3
-                @time dExTE[ii, :] = pardiSolver(AiiTE, PplusB)
+                dExTE[ii, :] = pardiSolver(AiiTE, PplusB)
 
             end
 
@@ -283,16 +283,16 @@ function compJacMat(exTE::Array{T}, hxTM::Array{T}, mt2dMesh::TensorMesh2D,
 
             # solve the pseudo forward problem
             if lsFlag == 0
-                @time dHxTM[ii, :]  = applyMUMPS(AinvTM[iFreq], PplusB)
+                dHxTM[ii, :]  = applyMUMPS(AinvTM[iFreq], PplusB)
 
             elseif lsFlag == 1
-                @time dHxTM[ii, :] = AiiTM \ (PplusB)
+                dHxTM[ii, :] = AiiTM \ (PplusB)
 
             elseif lsFlag == 2
-                @time dHxTM[ii, :] = mumpsSolver(AiiTM, PplusB)
+                dHxTM[ii, :] = mumpsSolver(AiiTM, PplusB)
 
             elseif lsFlag == 3
-                @time dHxTM[ii, :] = pardiSolver(AiiTM, PplusB)
+                dHxTM[ii, :] = pardiSolver(AiiTM, PplusB)
 
             end
 

--- a/HMCMT/src/MTSensitivity/compJacTMat.jl
+++ b/HMCMT/src/MTSensitivity/compJacTMat.jl
@@ -266,17 +266,17 @@ function compJacTMat(exTE::Array{T}, hxTM::Array{T}, mt2dMesh::TensorMesh2D,
 
             # solve the pseudo forward problem
             if lsFlag == 0
-                # @time eMat[ii, :] = applyMUMPS(AinvTE[iFreq], Lt[ii, :])
-                @time sTmp = applyMUMPS(AinvTE[iFreq], Lt[ii, :])
+                # eMat[ii, :] = applyMUMPS(AinvTE[iFreq], Lt[ii, :])
+                sTmp = applyMUMPS(AinvTE[iFreq], Lt[ii, :])
 
             elseif lsFlag == 1
-                @time sTmp = AiiTE \ full(Lt[ii, :])
+                sTmp = AiiTE \ full(Lt[ii, :])
 
             elseif lsFlag == 2
-                @time sTmp = mumpsSolver(AiiTE, Lt[ii, :])
+                sTmp = mumpsSolver(AiiTE, Lt[ii, :])
 
             elseif lsFlag == 3
-                @time sTmp = pardiSolver(AiiTE, full(Lt[ii, :]))
+                sTmp = pardiSolver(AiiTE, full(Lt[ii, :]))
 
             end
 
@@ -357,16 +357,16 @@ function compJacTMat(exTE::Array{T}, hxTM::Array{T}, mt2dMesh::TensorMesh2D,
 
             # solve the pseudo forward problem
             if lsFlag == 0
-                @time sTmp = applyMUMPS(AinvTM[iFreq], Lt[ii, :])
+                sTmp = applyMUMPS(AinvTM[iFreq], Lt[ii, :])
 
             elseif lsFlag == 1
-                @time sTmp = AiiTM \ full(Lt[ii, :])
+                sTmp = AiiTM \ full(Lt[ii, :])
 
             elseif lsFlag == 2
-                @time sTmp = mumpsSolver(AiiTM, Lt[ii, :])
+                sTmp = mumpsSolver(AiiTM, Lt[ii, :])
 
             elseif lsFlag == 3
-                @time sTmp = pardiSolver(AiiTM, full(Lt[ii, :]))
+                sTmp = pardiSolver(AiiTM, full(Lt[ii, :]))
 
             end
 

--- a/MUMPS/src/AOTCompat.jl
+++ b/MUMPS/src/AOTCompat.jl
@@ -1,0 +1,37 @@
+const _is_win = Sys.iswindows()
+
+function unix_readline(f, windows_line=_is_win)::Union{String, Nothing}
+    line = Char[]
+    try
+        while true
+            c = read(f, Char)
+            if windows_line && c == '\r'
+                c = read(f, Char)
+                @assert c == '\n' "read $c after newline"
+                break
+            end
+            c == '\n' && break
+            push!(line, c)
+        end
+        return String(line)
+    catch e
+        e isa EOFError && begin
+            return String(line)
+        end
+        throw(e)
+    end
+end
+
+
+function _time_seconds()
+    ccall(:time, UInt, (Ptr{Cvoid},), C_NULL)
+end
+
+macro compat_elapsed(ex)
+    quote
+        local t0 = _time_seconds()
+        local val = $(esc(ex))
+        local t1 = _time_seconds()
+        (float(t1 - t0), val)
+    end
+end

--- a/MUMPS/src/MUMPS.jl
+++ b/MUMPS/src/MUMPS.jl
@@ -1,5 +1,6 @@
 module MUMPS
 
+include("AOTCompat.jl")
 using SparseArrays
 using Printf
 using Distributed

--- a/MUMPS/src/MUMPSfuncs.jl
+++ b/MUMPS/src/MUMPSfuncs.jl
@@ -1,4 +1,4 @@
-
+using MUMPS: @compat_elapsed
 function solveMUMPS(A::SparseMatrixCSC{T1}, rhs::AbstractArray{T2},
 	                sym::Int=0,ooc::Int=0,tr::Int=0) where {T1,T2}
 
@@ -29,7 +29,7 @@ function factorMUMPS(A::SparseMatrixCSC{ComplexF64},sym::Int=0,ooc::Int=0)
     end
     n  = size(A,1);
     mumpsstat = [0];
-    facTime = @elapsed p  = ccall( (:factor_mumps_cmplx_, MUMPSlibPath),
+    facTime = @compat_elapsed p  = ccall( (:factor_mumps_cmplx_, MUMPSlibPath),
     		 Int64, ( Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{ComplexF64},
 			 Ptr{Int64}, Ptr{Int64}, Ptr{Int64}), Ref(n), Ref(sym), Ref(ooc),
 			 convert(Ptr{ComplexF64}, pointer(A.nzval)), A.rowval, A.colptr, mumpsstat);
@@ -46,7 +46,7 @@ function factorMUMPS(A::SparseMatrixCSC{Float64},sym::Int=0,ooc::Int=0)
     end
     n  = size(A,1);
     mumpsstat = [0];
-    facTime = @elapsed p  = ccall( (:factor_mumps_, MUMPSlibPath),
+    facTime = @compat_elapsed p  = ccall( (:factor_mumps_, MUMPSlibPath),
  	       Int64, ( Ptr{Int64}, Ptr{Int64}, Ptr{Int64}, Ptr{Float64},
 		   Ptr{Int64}, Ptr{Int64}, Ptr{Int64}),
            Ref(n), Ref(sym), Ref(ooc), A.nzval, A.rowval, A.colptr, mumpsstat);
@@ -78,7 +78,7 @@ function applyMUMPS(factor::MUMPSfactorization{T1},rhs::AbstractArray{T2,N},
 	id1 = myid()
 	id2 = factor.worker
 	if id1 != id2
-		warn("Worker $id1 has no access to MUMPS factorization stored on $id2. Trying to remotecall!")
+		@warn("Worker $id1 has no access to MUMPS factorization stored on $id2. Trying to remotecall!")
 		return remotecall_fetch(applyMUMPS,factor.worker,factor,rhs,x,tr)::Array{promote_type(T1,T2),N}
 	end
 

--- a/MUMPS/test/testTwoSystem.jl
+++ b/MUMPS/test/testTwoSystem.jl
@@ -20,14 +20,14 @@ rhs = randn(n,nrhs) + im*randn(n,nrhs);
 rhs2 = randn(n2,nrhs);
 
 println("Factorize complex matrix")
-@time F1 = factorMUMPS(A,1);
+F1 = factorMUMPS(A,1);
 
 
 println("Factorize real matrix")
-@time F2 = factorMUMPS(A2,1);
+F2 = factorMUMPS(A2,1);
 
 println("Solve complex system")
-@time x = applyMUMPS(F1,rhs);
+x = applyMUMPS(F1,rhs);
 err = zeros(nrhs)
 for i=1:nrhs
         err[i] =  norm(A*x[:,i]-rhs[:,i]) / norm(rhs[:,i]);
@@ -35,7 +35,7 @@ end
 @test maximum(err) < 1e-14
 
 println("Solve real system")
-@time x2 = applyMUMPS(F2,rhs2);
+x2 = applyMUMPS(F2,rhs2);
 err = zeros(nrhs)
 for i=1:nrhs
         err[i] =  norm(A2*x2[:,i]-rhs2[:,i]) / norm(rhs2[:,i]);


### PR DESCRIPTION
The main function used is located at `HMCMT/examples/coprod2/runHMScript.jl`.

The AOT compiler now works for `readstartupFile` and part of `runHMCSampler`.

Although SyslabCC does not support SparseArrays.jl, but it seems the uses in your project are mostly covered.

The current problem is `MT2DFwdSolver()` which returns one or two values based on a string parameter which cannot be optimized like a `if constexpr`.   